### PR TITLE
Trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atom-move-line package
 
-This package takes care of trailing commas when moving lines in json with 'editor:move-line-up' and 'editor:move-line-down'.
+This package takes care of trailing commas when moving lines in json with 'editor:move-line-up' and 'editor:move-line-down'. It also removes any trailing spaces from the moved lines.
 
 ![demo](https://raw.githubusercontent.com/pvorona/atom-move-line/master/images/demo.gif)
 

--- a/lib/atom-move-line.coffee
+++ b/lib/atom-move-line.coffee
@@ -36,10 +36,21 @@ moveLastChar = (from, to) -> (editor) ->
   atTheEndOfLine(to, => editor.insertText(lastChar))(editor)
   atTheEndOfLine(from, => editor.backspace())(editor)
 
+trimTrailingWhitespace = (from, to) -> (editor) ->
+  whitespaceRegex = /\s+$/
+  [from, to].forEach (row) ->
+    lineText = editor.lineTextForBufferRow(row)
+    if whitespaceRegex.test(lineText)
+      newLineText = lineText.replace(whitespaceRegex, "")
+      rowBufferRange = editor.bufferRangeForBufferRow(row)
+      editor.getBuffer().setTextInRange(rowBufferRange, newLineText)
+
 move = (from, to) -> (editor) ->
   editor.getCursorsOrderedByBufferPosition()
     .map (c) -> c.getBufferRow()
-    .forEach (row) -> moveLastChar(row + from, row + to)(editor)
+    .forEach (row) ->
+      trimTrailingWhitespace(row + from, row + to)(editor)
+      moveLastChar(row + from, row + to)(editor)
 
 subscriptions =
   'editor:move-line-up'  : -> withActiveEditor collapsingHistory preservingSelections splittingMultilineSelections move 1,  0

--- a/lib/atom-move-line.coffee
+++ b/lib/atom-move-line.coffee
@@ -1,6 +1,5 @@
 {CompositeDisposable} = require 'atom'
 
-# TODO: be ready for trailing spaces/tabs
 # TODO: autoinsert coma
 
 withActiveEditor = (action) ->


### PR DESCRIPTION
I saw in the comments that you wanted to handle trailing spaces, so I thought I would add the feature to remove any trailing whitespace before checking for commas.

It also serves the purpose of not adding whitespace to empty lines that get moved around, which is what Atom does by default (and I found that annoying, as it triggers errors in my linters).
